### PR TITLE
Ownership change; replace stock mpsc with crossbeam::channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +908,7 @@ dependencies = [
  "casey",
  "coreaudio-rs",
  "coremidi",
+ "crossbeam",
  "derive_builder",
  "env_logger",
  "indexmap",
@@ -866,6 +923,7 @@ dependencies = [
 name = "step-sequencer-tui"
 version = "0.1.0"
 dependencies = [
+ "crossbeam",
  "crossterm",
  "env_logger",
  "log",

--- a/step-sequencer-tui/Cargo.toml
+++ b/step-sequencer-tui/Cargo.toml
@@ -10,6 +10,7 @@ thiserror = "2.0.8"
 ratatui = "0.29.0"
 crossterm = "0.28.1"
 tui-input = "0.11.1"
+crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
 step-sequencer = { path = "../step-sequencer", features = ["jack"] }

--- a/step-sequencer-tui/src/tui.rs
+++ b/step-sequencer-tui/src/tui.rs
@@ -1,16 +1,13 @@
-use std::{
-    rc::Rc,
-    sync::mpsc::{self, Receiver, Sender},
-    thread,
-};
+use std::{rc::Rc, thread};
 
+use crossbeam::channel::{unbounded, Receiver, Sender};
 use crossterm::event::{self, Event, KeyCode};
 use log::info;
 use ratatui::{
-    layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Style, Stylize},
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, Padding, Paragraph, TableState, Widget},
+    widgets::{Block, Borders, List, ListItem, Padding, Paragraph},
     Frame,
 };
 use step_sequencer::{
@@ -23,10 +20,7 @@ use step_sequencer::{
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
-use crate::ui::{
-    tracker_view::{TrackerView, TrackerViewState},
-    BeatPad, Popup,
-};
+use crate::ui::{tracker_view::TrackerView, BeatPad, Popup};
 
 pub(crate) struct Tui {
     input: Input,
@@ -97,7 +91,7 @@ impl Tui {
         command_handler: impl Fn(&str) -> SSResult<()>,
     ) -> SSResult<()> {
         let mut terminal = ratatui::init();
-        let (event_sender, event_receiver) = mpsc::channel();
+        let (event_sender, event_receiver) = unbounded();
         {
             let event_sender = event_sender.clone();
             thread::spawn(move || {

--- a/step-sequencer/Cargo.toml
+++ b/step-sequencer/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { version = "1.11.0", features = ["fast-rng", "macro-diagnostics", "v4"] 
 jack = { version = "0.13.0", optional = true }
 coreaudio-rs = { version = "0.12.1", optional = true }
 coremidi = { version = "0.8.0", optional = true }
+crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 
 [features]
 jack = ["dep:jack"]

--- a/step-sequencer/src/audio/mod.rs
+++ b/step-sequencer/src/audio/mod.rs
@@ -1,8 +1,7 @@
 use core::fmt;
-use std::rc::Rc;
 
+use crate::beatmaker::BeatMakerSubscription;
 use crate::{
-    beatmaker::BeatMaker,
     midi::{note::Note, Channel, Velocity},
     SSResult,
 };
@@ -30,18 +29,18 @@ impl fmt::Display for Command {
 }
 
 pub trait SSClient {
-    fn start(&self) -> SSResult<()>;
-    fn stop(&self) -> SSResult<()>;
+    fn start(&mut self) -> SSResult<()>;
+    fn stop(&mut self) -> SSResult<()>;
 }
 
 #[cfg(feature = "jack")]
-pub fn create_ss_client(beatmaker: Rc<BeatMaker>) -> SSResult<Box<jack::SSJackClient>> {
+pub fn create_ss_client(beatmaker_subscription: BeatMakerSubscription) -> Box<dyn SSClient> {
     use self::jack::SSJackClient;
-    Ok(Box::new(SSJackClient::new(beatmaker)))
+    Box::new(SSJackClient::new(beatmaker_subscription))
 }
 
 #[cfg(feature = "coreaudio")]
-pub fn create_ss_client(beatmaker: Rc<BeatMaker>) -> SSResult<Box<coreaudio::SSCoreAudioClient>> {
+pub fn create_ss_client(beatmaker_subscription: BeatMakerSubscription) -> Box<dyn SSClient> {
     use self::coreaudio::SSCoreAudioClient;
-    Ok(Box::new(SSCoreAudioClient::new(beatmaker)))
+    Box::new(SSCoreAudioClient::new(beatmaker_subscription))
 }

--- a/step-sequencer/src/error.rs
+++ b/step-sequencer/src/error.rs
@@ -21,6 +21,8 @@ pub enum SSError {
     ParseIntError(#[from] ParseIntError),
     #[error("Parse note error: `{0}`")]
     ParseNoteError(#[from] ParseNoteError),
+    #[error("Channel recv error: `{0}`")]
+    RecvError(#[from] crossbeam::channel::RecvError),
     #[error("Unsupported platform: `{0}`")]
     UnsupportedPlatform(String),
     #[error("Unknown: `{0}`")]


### PR DESCRIPTION
Make Launcher the control center. Interactions with beatmaker, timeline, etc, should be done via Launcher.
Currently `project` is still `Rc<Project>` in Launcher. This may be fixed in the future.

Replaced all usages of `mpsc::channel`, `mpsc::sync_channel`, `Sender<...>` and `Receiver<...>` with their crossbeam equivalent.