### PR TITLE
Fix an edgecase where if a beat in a stretched (tempo scale < 1) track overlaps with a global beat, it is added twice from both the previous global beat and the one it overlaps with

### DIFF
--- a/step-sequencer-tui/src/tui.rs
+++ b/step-sequencer-tui/src/tui.rs
@@ -341,10 +341,13 @@ TODO
     fn render_info_view(&self, frame: &mut Frame, area: Rect) {
         let project_settings = self.project.project_settings();
         let project_settings = project_settings.read().unwrap();
-        let (current_beat, current_beat_millis) = *project_settings.current_beat.read().unwrap();
+        let current_beat_time = *project_settings.current_beat.read().unwrap();
         let info = List::new(vec![
             format!("Tempo: {}", project_settings.tempo),
-            format!("Current beat: {}+{}", current_beat, current_beat_millis),
+            format!(
+                "Current beat: {}+{}",
+                current_beat_time.0, current_beat_time.1
+            ),
         ])
         .block(Block::bordered().title("Info"));
         frame.render_widget(info, area);

--- a/step-sequencer/src/beatmaker/beat_timer.rs
+++ b/step-sequencer/src/beatmaker/beat_timer.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::sync::{Arc, RwLock};
 
 use derive_builder::Builder;
 use log::{debug, info};


### PR DESCRIPTION
Let me explain with the following example:

```
T1: A-------------------B-------------------C-------------------D  x1
T2: J---------------------------------------K  x1/2
```
T2 has an integer value of tempo scale, which means some beats on it (K) overlaps with global beats (C).

When we push global beat B into BeatSorter:
* Bugged version
  * We calculate the ceiling of `current beat (B) / tempo_scale`, which gives K.
  * We calculate the floor of `(current beat + 1 (C)) / tempo_scale`, which also gives us K.
  * If the above two are equal, we add it to the tree. In this case we do, which is wrong because we should be adding everything in the range [B, C), and K sits at the right boundary, which should be added when pushing global beat C.
* Fixed version
  * We calculate the ceiling of `current beat (B) / tempo_scale`, which gives K.
  * We the calculate the floor of `previous result * tempo_scale`, which gives C.
  * If we get back the same original global beat, we add it to the tree. In this case we don't since `B != C`.

When we push global beat C into BeatSorter:
* Bugged version
  * We calculate the ceiling of `current beat (C) / tempo_scale`, which gives K.
  * We calculate the floor of `(current beat + 1 (D)) / tempo_scale`, which also gives us K.
  * If the above two are equal, we add it to the tree. In this case we do, since we should be adding everything in the range [C, D), and K sits at the left boundary, it is correct that we added it this time.
* Fixed version
  * We calculate the ceiling of `current beat (C) / tempo_scale`, which gives K.
  * We the calculate the floor of `previous result * tempo_scale`, which gives C.
  * If we get back the same original global beat, we add it to the tree. In this case we do since `C == C`.