### PR TITLE
Precise timing (#3) phase 1: New BeatSorter that allows advancing to the given beat time

### DIFF
--- a/step-sequencer-gui/src/App.vue
+++ b/step-sequencer-gui/src/App.vue
@@ -16,7 +16,6 @@ interface Infinity {
 type NaN = "NaN";
 
 interface BeatTime {
-  integral: number;
   frac: Rational | Infinity | NaN,
 }
 
@@ -64,18 +63,18 @@ async function init() {
 onMounted(async () => {
   await init();
   listen<BeatSignal>('beat-signal', (event) => {
+    console.log(event);
     if ('Pause' === event.payload) {
       // Do nothing
     } else if ('Stop' === event.payload) {
       current_beat.value = "0";
     } else {
-      let integral = event.payload.Beat.integral;
       let frac = event.payload.Beat.frac;
       if ('NaN' === frac || 'Infinity' in frac) {
         current_beat.value = `WTF (${event.payload})`;
       } else {
         let [sign, [numer, denom]] = frac.Rational;
-        current_beat.value = `${sign === 'Plus' ? '' : '-'}${integral}+${numer}/${denom}`;
+        current_beat.value = `${sign === 'Plus' ? '' : '-'}${numer}/${denom}`;
       }
     }
 });

--- a/step-sequencer-tui/src/main.rs
+++ b/step-sequencer-tui/src/main.rs
@@ -1,16 +1,15 @@
 mod tui;
 mod ui;
-use std::{rc::Weak, sync::OnceLock};
+use std::sync::OnceLock;
 
 use crossbeam::channel::{unbounded, Sender};
 use log::info;
 use step_sequencer::{
-    audio::Command,
     beatmaker::pattern::{
         ExampleDrumTracks, EXAMPLE_DRUMTRACKS_BITWIG, EXAMPLE_DRUMTRACKS_GARAGEBAND,
     },
     error::{CommandError, SSError},
-    launcher::SSLauncher,
+    launcher::{Command, SSLauncher},
     midi::{note::Note, Channel, Velocity},
     project::F,
     timeline::TimelineState,
@@ -34,7 +33,7 @@ fn main() -> SSResult<()> {
         .unwrap();
     let mut ss_launcher = SSLauncher::new();
     let project = ss_launcher.project();
-    let beat_receiver = ss_launcher.subscribe_beatmaker_signals();
+    let beat_receiver = ss_launcher.subscribe_to_beatmaker();
     let example_drumtracks = if cfg!(target_os = "linux") {
         &EXAMPLE_DRUMTRACKS_BITWIG
     } else {

--- a/step-sequencer-tui/src/tui.rs
+++ b/step-sequencer-tui/src/tui.rs
@@ -13,12 +13,12 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Padding, Paragraph},
     Frame,
 };
+use step_sequencer::beatmaker::BeatMakerEvent;
 use step_sequencer::{
-    beatmaker::BeatSignal,
+    beatmaker::BeatMakerSubscription,
     drum_track::{DrumTrack, DrumTrackBeat},
     error::SSError,
     launcher::SSLauncher,
-    project::Project,
     SSResult,
 };
 use tui_input::backend::crossterm::EventHandler;
@@ -91,7 +91,7 @@ enum TuiEvent {
 impl<'a> Tui<'a> {
     pub fn run_tui(
         &mut self,
-        beat_signal_receiver: Receiver<BeatSignal>,
+        beatmaker_subscription: BeatMakerSubscription,
         log_receiver: Receiver<String>,
         mut command_handler: impl FnMut(&mut SSLauncher, &str) -> SSResult<()>,
     ) -> SSResult<()> {
@@ -113,7 +113,7 @@ impl<'a> Tui<'a> {
             });
         }
         thread::spawn(move || loop {
-            if let Ok(signal) = beat_signal_receiver.recv() {
+            if let Ok(signal) = beatmaker_subscription.receiver.recv() {
                 match signal {
                     _ => {
                         // Be it Beat, Pause or Stop, redraw anyways

--- a/step-sequencer/src/audio/jack/step_sequencer_client.rs
+++ b/step-sequencer/src/audio/jack/step_sequencer_client.rs
@@ -223,18 +223,22 @@ fn process_beatmaker(
 ) -> SSResult<()> {
     // TODO: Can NOT use while loop to process all messages in the channel.
     // Find out why.
-    if let Ok(event) = &subscription.receiver.try_recv() {
-        debug!("BeatMaker: subscription ID: {:?}", subscription.id);
-        debug!("BeatMaker: Received event from: {:?}", event);
-        let data = event.to_data()?;
-        debug!("BeatMaker: MIDI data: {:?}", data);
-        let time = match event {
-            ChannelVoiceEvent::NoteOff { .. } => 100,
-            _ => 0,
-        };
-        let raw_midi = RawMidi { time, bytes: &data };
-        let mut midi_writer = port.writer(process_scope);
-        midi_writer.write(&raw_midi)?;
+    let mut midi_writer = port.writer(process_scope);
+    let mut idx = 0;
+    while let Ok(event) = &subscription.receiver.try_recv() {
+        match *event {
+            crate::beatmaker::BeatMakerEvent::MIDIEvent(evt) => {
+                let data = evt.to_data()?;
+                info!("BeatMaker: MIDI data: {:?}", data);
+                let raw_midi = RawMidi {
+                    time: idx,
+                    bytes: &data,
+                };
+                midi_writer.write(&raw_midi)?;
+                idx += 1;
+            }
+            _ => {}
+        }
     }
     Ok(())
 }

--- a/step-sequencer/src/audio/jack/step_sequencer_client.rs
+++ b/step-sequencer/src/audio/jack/step_sequencer_client.rs
@@ -229,7 +229,7 @@ fn process_beatmaker(
         match *event {
             crate::beatmaker::BeatMakerEvent::MIDIEvent(evt) => {
                 let data = evt.to_data()?;
-                info!("BeatMaker: MIDI data: {:?}", data);
+                debug!("BeatMaker: MIDI data: {:?}", data);
                 let raw_midi = RawMidi {
                     time: idx,
                     bytes: &data,

--- a/step-sequencer/src/audio/mod.rs
+++ b/step-sequencer/src/audio/mod.rs
@@ -1,38 +1,9 @@
-use core::fmt;
-
 use crate::beatmaker::BeatMakerSubscription;
-use crate::project::{Tempo, F};
-use crate::{
-    midi::{note::Note, Channel, Velocity},
-    SSResult,
-};
+use crate::SSResult;
 #[cfg(feature = "coreaudio")]
 mod coreaudio;
 #[cfg(feature = "jack")]
 mod jack;
-
-#[derive(Clone, Debug)]
-pub enum Command {
-    PlayOrPause,
-    Stop,
-    Quit,
-    ChangeTempo(Tempo),
-    AddTrack,
-    RenameTrack(usize, String),
-    ToggleBeat(usize, usize),
-    Resize(usize, usize),
-    TempoScale(usize, F),
-    SetChannel(usize, Channel),
-    SetVelocity(usize, Velocity),
-    SetNote(usize, Note),
-    Debug,
-}
-
-impl fmt::Display for Command {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
 
 pub trait SSClient {
     fn start(&mut self) -> SSResult<()>;

--- a/step-sequencer/src/beatmaker/beat_sorter.rs
+++ b/step-sequencer/src/beatmaker/beat_sorter.rs
@@ -1,41 +1,108 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+};
 
-use crate::{drum_track::Beat, id::SSId};
+use crate::{
+    drum_track::{Beat, DrumTrack},
+    id::SSId,
+    midi::ChannelVoiceEvent,
+    project::{TrackMap, F},
+};
 
-use super::BeatTime;
+use super::beat_time::BeatTime;
 
-/// BeatSorter keeps track of the next note from each track to play
-/// and ensure they are played in order.
-#[derive(Default)]
 pub struct BeatSorter {
-    treemap: BTreeMap<BeatTime, Vec<(SSId, Option<Vec<Beat>>)>>,
+    tracks: Arc<RwLock<TrackMap>>,
+    current_beat_time: BeatTime,
+}
+
+fn find_next_beat_in_track(track: &DrumTrack, beat_time: BeatTime) -> usize {
+    let idx = if beat_time.fraction() > F::from(0) {
+        // We are between two beats
+        beat_time.integral() + 1
+    } else {
+        beat_time.integral()
+    };
+    return idx % track.len();
+}
+
+/// Get beats from start (inclusive) to end (exclusive) respecting track tempo scale
+/// `start` and `end` are global beat time (i.e. when tempo scale = 1)
+fn get_beats_between_in_track(
+    track: &DrumTrack,
+    start: BeatTime,
+    end: BeatTime,
+) -> Vec<(BeatTime, Beat)> {
+    let tempo_scale = track.get_tempo_scale();
+    let mut start_scaled = start.stretch(tempo_scale).ceil();
+    let end_scaled = end.stretch(tempo_scale);
+    let mut result = vec![];
+    while start_scaled < end_scaled {
+        let idx = find_next_beat_in_track(track, start_scaled);
+        let beats = track.get_as_beats(idx).flatten();
+        if let Some(beats) = beats {
+            result.extend(
+                beats
+                    .into_iter()
+                    .map(|b| (start_scaled.compress(tempo_scale), b)),
+            );
+        }
+        start_scaled = start_scaled.add_integral(1);
+    }
+
+    return result;
+}
+
+fn beat_to_channel_voice_events(beat: Beat) -> [ChannelVoiceEvent; 2] {
+    [
+        ChannelVoiceEvent::NoteOn {
+            channel: beat.channel,
+            key: beat.note.into(),
+            velocity: beat.velocity,
+        },
+        ChannelVoiceEvent::NoteOff {
+            channel: beat.channel,
+            key: beat.note.into(),
+            velocity: beat.velocity,
+        },
+    ]
 }
 
 impl BeatSorter {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn len(&self) -> usize {
-        self.treemap.len()
+    pub fn with_tracks(tracks: Arc<RwLock<TrackMap>>) -> Self {
+        Self {
+            tracks,
+            current_beat_time: BeatTime::zero(),
+        }
     }
 
     pub fn reset(&mut self) {
-        self.treemap.clear();
+        self.current_beat_time = BeatTime::zero();
     }
 
-    pub fn push(&mut self, track_id: SSId, beat_time: BeatTime, beat: Option<Vec<Beat>>) {
-        self.treemap
-            .entry(beat_time)
-            .or_default()
-            .push((track_id, beat));
+    pub fn jump(&mut self, beat_time: BeatTime) {
+        self.current_beat_time = beat_time;
     }
 
-    pub fn pop(&mut self) -> Option<(BeatTime, Vec<(SSId, Option<Vec<Beat>>)>)> {
-        self.treemap.pop_first()
-    }
-
-    pub fn top(&self) -> Option<(&BeatTime, &Vec<(SSId, Option<Vec<Beat>>)>)> {
-        self.treemap.first_key_value()
+    pub fn advance(
+        &mut self,
+        next_beat_time: BeatTime,
+    ) -> Vec<(BeatTime, Vec<(SSId, ChannelVoiceEvent)>)> {
+        let mut treemap: BTreeMap<BeatTime, Vec<_>> = BTreeMap::new();
+        for (id, track) in self.tracks.read().unwrap().iter() {
+            for (beat_time, beat) in
+                get_beats_between_in_track(track, self.current_beat_time, next_beat_time)
+            {
+                let [note_on, note_off] = beat_to_channel_voice_events(beat);
+                treemap.entry(beat_time).or_default().push((*id, note_on));
+                treemap
+                    .entry(beat_time.add_fraction(F::new(1u64, 4u64)))
+                    .or_default()
+                    .push((*id, note_off));
+            }
+        }
+        self.current_beat_time = next_beat_time;
+        return treemap.into_iter().collect();
     }
 }

--- a/step-sequencer/src/beatmaker/beat_sorter_old.rs
+++ b/step-sequencer/src/beatmaker/beat_sorter_old.rs
@@ -1,0 +1,41 @@
+use std::collections::BTreeMap;
+
+use crate::{drum_track::Beat, id::SSId};
+
+use super::BeatTime;
+
+/// BeatSorter keeps track of the next note from each track to play
+/// and ensure they are played in order.
+#[derive(Default)]
+pub struct BeatSorterOld {
+    treemap: BTreeMap<BeatTime, Vec<(SSId, Option<Vec<Beat>>)>>,
+}
+
+impl BeatSorterOld {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.treemap.len()
+    }
+
+    pub fn reset(&mut self) {
+        self.treemap.clear();
+    }
+
+    pub fn push(&mut self, track_id: SSId, beat_time: BeatTime, beat: Option<Vec<Beat>>) {
+        self.treemap
+            .entry(beat_time)
+            .or_default()
+            .push((track_id, beat));
+    }
+
+    pub fn pop(&mut self) -> Option<(BeatTime, Vec<(SSId, Option<Vec<Beat>>)>)> {
+        self.treemap.pop_first()
+    }
+
+    pub fn top(&self) -> Option<(&BeatTime, &Vec<(SSId, Option<Vec<Beat>>)>)> {
+        self.treemap.first_key_value()
+    }
+}

--- a/step-sequencer/src/beatmaker/mod.rs
+++ b/step-sequencer/src/beatmaker/mod.rs
@@ -2,67 +2,47 @@ pub mod beat_sorter;
 pub mod beat_time;
 pub mod pattern;
 
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    sync::{Arc, RwLock, RwLockReadGuard},
-    thread,
-};
+use std::thread;
 
 use beat_sorter::BeatSorter;
 use beat_time::BeatTime;
 use crossbeam::{
-    channel::{bounded, unbounded, Receiver, Sender},
+    channel::{bounded, Receiver, Sender},
     select,
 };
 use log::{debug, info};
 
 use crate::{
-    drum_track::Beat,
-    id::{AutoIncrementId, AutoIncrementIdGen},
+    consts,
     midi::ChannelVoiceEvent,
-    project::{Project, TrackMap, F},
+    models::channel_subscription::{ChannelEventSubscription, ChannelEventSubscriptionModel},
+    project::{Project, F},
     timeline::{TimelineEvent, TimelineSubscription},
 };
-
-fn send_beat(subscribers: &RwLockReadGuard<BeatMakerSubscriberMap>, beat: &Beat) {
-    debug!("BeatMaker: Sending events");
-    for sender in subscribers.values() {
-        let _ = sender.send(ChannelVoiceEvent::NoteOn {
-            channel: beat.channel,
-            key: beat.note.into(),
-            velocity: beat.velocity,
-        });
-        let _ = sender.send(ChannelVoiceEvent::NoteOff {
-            channel: beat.channel,
-            key: beat.note.into(),
-            velocity: beat.velocity,
-        });
-    }
-}
-
-#[derive(Clone, serde::Serialize)]
-pub enum BeatSignal {
-    Beat(BeatTime),
-    Pause,
-    Stop,
-}
 
 enum InternalSignal {
     ResetSorter,
 }
 
-type BeatMakerSubscriberMap = HashMap<AutoIncrementId, Sender<ChannelVoiceEvent>>;
-type SignalSubscriberMap = Vec<Sender<BeatSignal>>;
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+pub enum BeatMakerEvent {
+    Pause,                        // Timeline pause
+    Stop,                         // Timeline reset
+    CompleteTick(u64),            // Passthru of timeline ticks
+    Step(u64),                    // Global steps elapsed
+    Beat(BeatTime),               // Track beat
+    MIDIEvent(ChannelVoiceEvent), // MIDI event to be processed by audio server
+}
+
+pub type BeatMakerSubscriptionModel = ChannelEventSubscriptionModel<BeatMakerEvent>;
+pub type BeatMakerSubscription = ChannelEventSubscription<BeatMakerEvent>;
 
 /// BeatMaker sends walks along the timeline and send out beats of every track
 /// as MIDI notes.
 /// Internally, it maintains a search tree of the next upcoming notes of each track.
 /// This ensures all notes are sent out in the correct order.
 pub struct BeatMaker {
-    subscribers: Arc<RwLock<BeatMakerSubscriberMap>>,
-    signal_subscribers: Arc<RwLock<SignalSubscriberMap>>,
-    idgen: RwLock<AutoIncrementIdGen>,
+    subscription_model: BeatMakerSubscriptionModel,
     internal_signal: (Sender<InternalSignal>, Receiver<InternalSignal>),
 }
 
@@ -71,51 +51,17 @@ impl BeatMaker {
         Default::default()
     }
     pub fn subscribe(&self) -> BeatMakerSubscription {
-        let next_id = self.idgen.write().unwrap().next();
-        let (sender, receiver) = unbounded();
-        let mut subscriber_map = self.subscribers.write().unwrap();
-        subscriber_map.insert(next_id, sender);
-
-        BeatMakerSubscription {
-            id: next_id,
-            receiver,
-            subscribers: self.subscribers.clone(),
-        }
-    }
-
-    pub fn subscribe_signals(&self) -> Receiver<BeatSignal> {
-        let mut signal_subscribers = self.signal_subscribers.write().unwrap();
-        let (sender, receiver) = unbounded();
-        signal_subscribers.push(sender);
-        return receiver;
-    }
-
-    fn populate_beat_sorter_for_beat_time(
-        beat_sorter: &mut BeatSorter,
-        current_beat_time: BeatTime,
-        tracks: &TrackMap,
-    ) {
-        for (track_id, track) in tracks.iter() {
-            let tempo_scale = track.get_tempo_scale();
-            let track_beat_time = current_beat_time.stretch(tempo_scale).ceil();
-            beat_sorter.push(
-                *track_id,
-                track_beat_time.compress(tempo_scale),
-                track.get_as_beats(track_beat_time.integral()).flatten(),
-            );
-        }
+        self.subscription_model.subscribe()
     }
 
     pub fn start(&self, project: &Project, timeline_subscription: TimelineSubscription) {
         let project_settings = project.project_settings();
         let tracks = project.tracks();
-        let subscribers = self.subscribers.clone();
-        let signal_subscribers = self.signal_subscribers.clone();
         let internal_signal_receiver = self.internal_signal.1.clone();
+        let subscriber_map = self.subscription_model.subscriber_map().clone();
         thread::spawn(move || {
             info!("BeatMaker started");
-            let interval = timeline_subscription.interval;
-            let mut beat_sorter = BeatSorter::new();
+            let mut beat_sorter = BeatSorter::with_tracks(tracks);
             let mut current_beat_time = BeatTime::zero();
             loop {
                 select! {
@@ -123,7 +69,6 @@ impl BeatMaker {
                         match signal {
                             Ok(InternalSignal::ResetSorter) => {
                                 beat_sorter.reset();
-                                Self::populate_beat_sorter_for_beat_time(&mut beat_sorter, current_beat_time, &tracks.read().unwrap());
                             }
                             Err(err) => {
                                 info!("Internal signal sender: {}. Exiting BeatMaker thread.", err);
@@ -135,61 +80,28 @@ impl BeatMaker {
                     recv(timeline_subscription.receiver) -> tick => {
                         match tick.unwrap() {
                             TimelineEvent::Tick(tick) => {
-                                if tick == 0 {
-                                    // Start playing
-                                    Self::populate_beat_sorter_for_beat_time(
-                                        &mut beat_sorter,
-                                        current_beat_time,
-                                        &tracks.read().unwrap(),
-                                    );
-                                }
-                                let project_settings = project_settings.read().unwrap();
-                                *project_settings.current_beat_time.write().unwrap() = current_beat_time;
-                                let tempo = project_settings.tempo;
-                                drop(project_settings);
-                                let subscribers = subscribers.read().unwrap();
-                                while beat_sorter.top().is_some() {
-                                    if *beat_sorter.top().unwrap().0 > current_beat_time {
-                                        break;
-                                    }
-                                    let (beat_time, beats) = beat_sorter.pop().unwrap();
-                                    let tracks = tracks.read().unwrap();
-                                    for (track_id, beats_in_track) in beats {
-                                        if let Some(bs) = beats_in_track {
-                                            bs.iter().for_each(|b| send_beat(&subscribers, &b));
+                                let tempo = {
+                                    let project_settings = project_settings.read().unwrap();
+                                    *project_settings.current_beat_time.write().unwrap() = current_beat_time;
+                                    project_settings.tempo
+                                };
 
-                                        }
-                                        if let Some(track) = tracks.get(&track_id) {
-                                            let tempo_scale = track.get_tempo_scale();
-                                            let track_beat_time =
-                                                current_beat_time.stretch(tempo_scale);
-                                            let next_track_beat_time = track_beat_time.add_integral(1).floor();
-                                            let next_beat_idx = if track.is_empty() {
-                                                0
-                                            } else {
-                                                next_track_beat_time.integral() % track.len()
-                                            };
-                                            let next_beat = track
-                                                .get_as_beats(next_beat_idx)
-                                                .flatten();
-                                            beat_sorter.push(track_id,
-                                                next_track_beat_time.compress(tempo_scale), next_beat);
-                                        }
+                                let beat_time_per_tick =
+                                    F::new(tempo as u64 * consts::TIMELINE_TICK_DURATION.as_millis() as u64, 60_000u64);
+                                let beat_time = BeatTime::new(beat_time_per_tick * tick);
+                                let beats = beat_sorter.advance(beat_time);
+                                for (_beat_time, beats) in beats.iter() {
+                                    BeatMakerSubscriptionModel::send_all(&subscriber_map, BeatMakerEvent::Beat(beat_time));
+                                    for (_id, beat) in beats {
+                                        BeatMakerSubscriptionModel::send_all(&subscriber_map, BeatMakerEvent::MIDIEvent(*beat));
                                     }
-                                    let signal_subscribers = signal_subscribers.read().unwrap();
-                                    for signal_subscriber in signal_subscribers.iter() {
-                                        signal_subscriber.send(BeatSignal::Beat(beat_time));
-                                    }
+
                                 }
-                                let beat_time_incr =
-                                    F::new(tempo as u64 * interval.as_millis() as u64, 60_000u64);
-                                current_beat_time = current_beat_time.add_fraction(beat_time_incr);
+
+                                current_beat_time = beat_time;
                             }
                             TimelineEvent::Pause => {
-                                let signal_subscribers = signal_subscribers.read().unwrap();
-                                for signal_subscriber in signal_subscribers.iter() {
-                                    signal_subscriber.send(BeatSignal::Pause);
-                                }
+                                BeatMakerSubscriptionModel::send_all(&subscriber_map, BeatMakerEvent::Pause);
                             }
                             TimelineEvent::Stop => {
                                 *project_settings
@@ -200,10 +112,7 @@ impl BeatMaker {
                                     .unwrap() = BeatTime::zero();
                                 current_beat_time = BeatTime::zero();
                                 beat_sorter.reset();
-                                let signal_subscribers = signal_subscribers.read().unwrap();
-                                for signal_subscriber in signal_subscribers.iter() {
-                                    signal_subscriber.send(BeatSignal::Stop);
-                                }
+                                BeatMakerSubscriptionModel::send_all(&subscriber_map, BeatMakerEvent::Stop);
                             }
                         }
                     }
@@ -220,25 +129,10 @@ impl BeatMaker {
 impl Default for BeatMaker {
     fn default() -> Self {
         Self {
-            subscribers: Default::default(),
-            signal_subscribers: Default::default(),
-            idgen: Default::default(),
+            subscription_model: Default::default(),
             internal_signal: bounded(1),
         }
     }
 }
 
 pub struct BeatMakerAsyncHandle;
-
-pub struct BeatMakerSubscription {
-    pub id: AutoIncrementId,
-    pub receiver: Receiver<ChannelVoiceEvent>,
-    pub subscribers: Arc<RwLock<BeatMakerSubscriberMap>>,
-}
-
-impl Drop for BeatMakerSubscription {
-    fn drop(&mut self) {
-        let mut subscriber_map = self.subscribers.write().unwrap();
-        subscriber_map.remove(&self.id);
-    }
-}

--- a/step-sequencer/src/beatmaker/pattern.rs
+++ b/step-sequencer/src/beatmaker/pattern.rs
@@ -1,35 +1,14 @@
-use std::{iter::repeat, sync::RwLockReadGuard};
+use std::iter::repeat;
 
 use log::debug;
 
 use crate::{
     drum_track::{DrumTrack, DrumTrackBeat},
-    midi::{note::Note, ChannelVoiceEvent, Key},
+    midi::note::Note,
 };
 
 use crate::drum_track::Beat;
 use crate::drum_track::DrumTrackBeat::*;
-
-use super::BeatMakerSubscriberMap;
-
-fn send_key<K>(subscribers: &RwLockReadGuard<BeatMakerSubscriberMap>, key: &K)
-where
-    K: Clone + Into<Key>,
-{
-    debug!("BeatMaker: Sending events");
-    for sender in subscribers.values() {
-        let _ = sender.send(ChannelVoiceEvent::NoteOn {
-            channel: 9, // is 10 to human
-            key: key.clone().into(),
-            velocity: 80,
-        });
-        let _ = sender.send(ChannelVoiceEvent::NoteOff {
-            channel: 9, // is 10 to human
-            key: key.clone().into(),
-            velocity: 80,
-        });
-    }
-}
 
 macro_rules! beat {
     ($channel:expr, $note:expr, $velocity:expr) => {

--- a/step-sequencer/src/consts.rs
+++ b/step-sequencer/src/consts.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::{drum_track::Beat, midi::note::Note};
 
 pub const TRACK_DEFAULT_BEAT: Beat = Beat {
@@ -6,3 +8,5 @@ pub const TRACK_DEFAULT_BEAT: Beat = Beat {
     velocity: 72,
 };
 pub const BEAT_TIME_MICRO: u32 = 1_000_000;
+
+pub const TIMELINE_TICK_DURATION: Duration = Duration::from_millis(10);

--- a/step-sequencer/src/error.rs
+++ b/step-sequencer/src/error.rs
@@ -1,7 +1,7 @@
 use std::{io, num::ParseIntError};
 use thiserror::Error;
 
-use crate::{audio::Command, midi::note::ParseNoteError};
+use crate::{launcher::Command, midi::note::ParseNoteError};
 
 pub type SSResult<T> = std::result::Result<T, SSError>;
 

--- a/step-sequencer/src/lib.rs
+++ b/step-sequencer/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod id;
 pub mod launcher;
 pub mod midi;
+pub mod models;
 pub mod project;
 pub mod timeline;
 

--- a/step-sequencer/src/midi/mod.rs
+++ b/step-sequencer/src/midi/mod.rs
@@ -8,7 +8,7 @@ pub type Key = u8; // TODO:
 pub type Channel = u8;
 pub type Velocity = u8;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, serde::Serialize)]
 pub enum ChannelVoiceEvent {
     NoteOn {
         channel: Channel,

--- a/step-sequencer/src/models/channel_subscription.rs
+++ b/step-sequencer/src/models/channel_subscription.rs
@@ -1,0 +1,83 @@
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+};
+
+use crossbeam::channel::{unbounded, Receiver, SendError, Sender};
+
+use crate::id::{AutoIncrementId, AutoIncrementIdGen};
+
+pub type ChannelEventSubscriberMap<T> = BTreeMap<AutoIncrementId, Sender<T>>;
+
+pub struct ChannelEventSubscriptionModel<T> {
+    channel_creator: Box<dyn 'static + Send + Fn() -> (Sender<T>, Receiver<T>)>,
+    id_gen: RwLock<AutoIncrementIdGen>,
+    subscriber_map: Arc<RwLock<ChannelEventSubscriberMap<T>>>,
+}
+
+impl<T: Clone> ChannelEventSubscriptionModel<T> {
+    pub fn new(channel_creator: impl 'static + Send + Fn() -> (Sender<T>, Receiver<T>)) -> Self {
+        Self {
+            channel_creator: Box::new(channel_creator),
+            id_gen: Default::default(),
+            subscriber_map: Default::default(),
+        }
+    }
+
+    pub fn subscribe(&self) -> ChannelEventSubscription<T> {
+        let next_id = self.id_gen.write().unwrap().next();
+        let (sender, receiver) = (self.channel_creator)();
+        self.subscriber_map.write().unwrap().insert(next_id, sender);
+        return ChannelEventSubscription {
+            id: next_id,
+            receiver,
+            subscribers: self.subscriber_map.clone(),
+        };
+    }
+
+    pub fn subscriber_map(&self) -> &Arc<RwLock<ChannelEventSubscriberMap<T>>> {
+        &self.subscriber_map
+    }
+
+    // This is terrible
+    pub fn send_all(
+        subscriber_map: &Arc<RwLock<ChannelEventSubscriberMap<T>>>,
+        event: T,
+    ) -> Result<(), Vec<(AutoIncrementId, SendError<T>)>> {
+        let mut errors = vec![];
+        for (id, subscriber) in subscriber_map.read().unwrap().iter() {
+            if let Err(err) = subscriber.send(event.clone()) {
+                errors.push((*id, err));
+            }
+        }
+        if errors.is_empty() {
+            return Ok(());
+        }
+        return Err(errors);
+    }
+}
+
+unsafe impl<T> Sync for ChannelEventSubscriptionModel<T> {}
+
+impl<T> Default for ChannelEventSubscriptionModel<T> {
+    fn default() -> Self {
+        Self {
+            channel_creator: Box::new(|| unbounded()),
+            id_gen: Default::default(),
+            subscriber_map: Default::default(),
+        }
+    }
+}
+
+pub struct ChannelEventSubscription<T> {
+    pub id: AutoIncrementId,
+    pub receiver: Receiver<T>,
+    subscribers: Arc<RwLock<ChannelEventSubscriberMap<T>>>,
+}
+
+impl<T> Drop for ChannelEventSubscription<T> {
+    fn drop(&mut self) {
+        let mut subscriber_map = self.subscribers.write().unwrap();
+        subscriber_map.remove(&self.id);
+    }
+}

--- a/step-sequencer/src/models/mod.rs
+++ b/step-sequencer/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod channel_subscription;


### PR DESCRIPTION
### Summary

Creates a new BeatSorter that allows advancing to the given beat time, returning all NoteOn/NoteOff events to send in the period.

Currently the next beat time to advance to is still given by the Timeline, thus precise timing is not achieved. However, the new implementation of BeatSorter handles NoteOn/NoteOff correctly with desired note duration. It also can be used independently from Timeline ticks, and paves the way to eventual precise timing in both JACK and CoreAudio.

### JACK
This accommodates JACK's process cycle, where I can convert `last_frame_time` to beat time, and use BeatSorter to get all the beats with their relative frames to process in this cycle. In the future, we might even be able to get rid of Timeline and use JACK to drive the timeline instead (pause and stop) is a separate discussion.

### CoreAudio
I can continue to use Timeline and advance the new BeatSorter to the next tick, and send NoteOn/NoteOff events with precise timestamps.